### PR TITLE
[IMP] Add widget="url" to the URL field in the Tree View of Google Sheets

### DIFF
--- a/addons/google_spreadsheet/views/google_spreadsheet_views.xml
+++ b/addons/google_spreadsheet/views/google_spreadsheet_views.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <tree string="Google Spreadsheets">
                     <field name="name" string="Name"/>
-                    <field name="url" />
+                    <field name="url" widget="url" />
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Users can now click this field, instead of having Odoo open the Form View to click it.

Benefits:
1. Saves the user from clicking TWICE (they only have to click ONCE with this PR)
2. Keeps the list view of all spreadsheets open (user has to GO BACK to see the list without this PR)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
